### PR TITLE
Fix MVG Api

### DIFF
--- a/providers/mvv_provider.py
+++ b/providers/mvv_provider.py
@@ -113,7 +113,7 @@ class MvvgApi:
             "limit": limit,
             "transportTypes": str.join(',', transport_types),
         }
-        result = requests.get("https://mvg.de/api/fib/v2/departure", params=params)
+        result = requests.get("https://mvg.de/api/bgw-pt/v3/departures", params=params)
 
         json = result.json()
         return json

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ mss==9.0.2
 numpy==2.1.2
 Pillow==10.4.0
 requests==2.32.3
+pytz==2024.2


### PR DESCRIPTION
Hab heute mittag bemerkt, dass die MVG ihren API endpoint für Abfahrten umbenannt haben.
API Struktur bleibt aber gleich

Nebenbei habe ich pytz zu requirements.txt hinzugefügt. Dieses Paket wird bereits genutzt, war bisher aber nicht in den requirements gelistet